### PR TITLE
feat: service provider implementation for with axios and react query

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,5 @@
+import { AxiosProvider } from "@libs/axios/context/AxiosContext";
+import { AxiosServiceProvider } from "@libs/axios/service/context";
 import { QueryClientProvider } from "@libs/query-client";
 import { BrowserRouter, Navigate, Route, Routes } from "@libs/router";
 
@@ -5,16 +7,20 @@ import { ExamplesOverview } from "./features";
 
 export const App = () => {
   return (
-    <QueryClientProvider>
-      <BrowserRouter>
-        <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-          <h1>React Vite TS Boilerplate</h1>
-          <Routes>
-            <Route path="examples" element={<ExamplesOverview id="test" />} />
-            <Route path="*" element={<Navigate to="/examples" replace />} />
-          </Routes>
-        </div>
-      </BrowserRouter>
-    </QueryClientProvider>
+    <AxiosProvider>
+      <AxiosServiceProvider>
+        <QueryClientProvider>
+          <BrowserRouter>
+            <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+              <h1>React Vite TS Boilerplate</h1>
+              <Routes>
+                <Route path="examples" element={<ExamplesOverview id="test" />} />
+                <Route path="*" element={<Navigate to="/examples" replace />} />
+              </Routes>
+            </div>
+          </BrowserRouter>
+        </QueryClientProvider>
+      </AxiosServiceProvider>
+    </AxiosProvider>
   );
 };

--- a/src/features/examples/api/useExampleQuery.ts
+++ b/src/features/examples/api/useExampleQuery.ts
@@ -1,0 +1,15 @@
+import { useAxiosService } from "@libs/axios";
+import { useQuery } from "@libs/query-client";
+
+const useExampleQuery = () => {
+  const { getAllService } = useAxiosService();
+
+  const { data } = useQuery({
+    queryKey: ["todos"],
+    queryFn: () => getAllService({ url: "/todos" }),
+  });
+
+  return { todos: data };
+};
+
+export default useExampleQuery;

--- a/src/features/examples/api/useGetExamples.ts
+++ b/src/features/examples/api/useGetExamples.ts
@@ -1,6 +1,7 @@
 import { useInvalidateQueries, useQuery } from "@libs/query-client";
 
 import { Example } from "./types";
+import useExampleQuery from "./useExampleQuery";
 
 type UseGetExamplesOptions = {
   id: string;
@@ -10,6 +11,9 @@ export const useGetExamples = (options: UseGetExamplesOptions) => {
   const { id } = options;
 
   const { invalidateQueries } = useInvalidateQueries();
+  const { todos } = useExampleQuery();
+
+  console.log({ todos });
 
   const queryKey = ["getExamples", { id }];
 

--- a/src/libs/axios/context/AxiosContext.tsx
+++ b/src/libs/axios/context/AxiosContext.tsx
@@ -1,0 +1,39 @@
+import Axios, { AxiosInstance } from "axios";
+import { createContext, ReactNode } from "react";
+
+export const AxiosContext = createContext<AxiosInstance | null>(null);
+
+export const AxiosProvider = (props: { children: ReactNode }) => {
+  const { children } = props;
+  const axiosInstance = Axios.create({
+    withCredentials: true,
+    baseURL: import.meta.env.VITE_API_BASE_URL || "https://example.com/api",
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-cache",
+    },
+  });
+
+  axiosInstance.interceptors.request.use(
+    (config) => {
+      const token = localStorage.getItem("token");
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`;
+      }
+      return config;
+    },
+    (error) => Promise.reject(error)
+  );
+
+  axiosInstance.interceptors.response.use(
+    (response) => response,
+    (error) => {
+      if (error?.response?.status === 401) {
+        window.location.replace("/login");
+      }
+      return Promise.reject(error);
+    }
+  );
+
+  return <AxiosContext.Provider value={axiosInstance}>{children}</AxiosContext.Provider>;
+};

--- a/src/libs/axios/context/index.ts
+++ b/src/libs/axios/context/index.ts
@@ -1,0 +1,2 @@
+export * from "./AxiosContext";
+export * from "./useAxios";

--- a/src/libs/axios/context/useAxios.ts
+++ b/src/libs/axios/context/useAxios.ts
@@ -1,0 +1,9 @@
+import { useContext } from "react";
+
+import { AxiosContext } from "./AxiosContext";
+
+export const useAxios = () => {
+  const context = useContext(AxiosContext);
+  if (!context) throw new Error("useAxios must be used within AxiosProvider");
+  return context;
+};

--- a/src/libs/axios/hooks/index.ts
+++ b/src/libs/axios/hooks/index.ts
@@ -1,0 +1,10 @@
+export { useGetAllService } from "./useGetAllService";
+export type { UseGetAllServiceType } from "./useGetAllService";
+export { useGetService } from "./useGetService";
+export type { UseGetServiceType } from "./useGetService";
+export { useCreateService } from "./useCreateService";
+export type { UseCreateServiceType } from "./useCreateService";
+export { useDeleteService } from "./useDeleteService";
+export type { UseDeleteServiceType } from "./useDeleteService";
+export { useUpdateService } from "./useUpdateService";
+export type { UseUpdateServiceType } from "./useUpdateService";

--- a/src/libs/axios/hooks/useCreateService.ts
+++ b/src/libs/axios/hooks/useCreateService.ts
@@ -1,0 +1,27 @@
+import { AxiosError } from "axios";
+
+import { useAxios } from "../context";
+
+export type UseCreateServiceType<TPayload> = {
+  url: string;
+  payload: TPayload;
+};
+
+export const useCreateService = <TResponse, TPayload>() => {
+  const axios = useAxios();
+
+  const sendRequest = async (props: UseCreateServiceType<TPayload>): Promise<{ data?: TResponse; error?: string }> => {
+    const { url, payload } = props;
+    try {
+      const response = await axios.post<TResponse>(url, payload);
+      return { data: response.data };
+    } catch (err) {
+      const axiosError = err as AxiosError;
+      return {
+        error: axiosError.response?.data ? JSON.parse(JSON.stringify(axiosError.response)) : axiosError.message,
+      };
+    }
+  };
+
+  return { sendRequest };
+};

--- a/src/libs/axios/hooks/useDeleteService.ts
+++ b/src/libs/axios/hooks/useDeleteService.ts
@@ -1,0 +1,27 @@
+import { AxiosError } from "axios";
+
+import { useAxios } from "../context";
+
+export type UseDeleteServiceType = {
+  id: string | number;
+  url: string;
+};
+
+export const useDeleteService = <TResponse>() => {
+  const axios = useAxios();
+
+  const sendRequest = async (props: UseDeleteServiceType): Promise<{ data?: TResponse; error?: string }> => {
+    const { url, id } = props;
+    try {
+      const response = await axios.delete<TResponse>(`${url}/${id}`);
+      return { data: response.data };
+    } catch (err) {
+      const axiosError = err as AxiosError;
+      return {
+        error: axiosError.response?.data ? JSON.parse(JSON.stringify(axiosError.response)) : axiosError.message,
+      };
+    }
+  };
+
+  return { sendRequest };
+};

--- a/src/libs/axios/hooks/useGetAllService.ts
+++ b/src/libs/axios/hooks/useGetAllService.ts
@@ -1,0 +1,26 @@
+import { AxiosError } from "axios";
+
+import { useAxios } from "../context";
+
+export type UseGetAllServiceType = {
+  url: string;
+};
+
+export const useGetAllService = <T>() => {
+  const axios = useAxios();
+
+  const sendRequest = async (props: UseGetAllServiceType): Promise<{ data?: T; error?: string }> => {
+    const { url } = props;
+    try {
+      const response = await axios.get<T>(url);
+      return { data: response.data };
+    } catch (err) {
+      const axiosError = err as AxiosError;
+      return {
+        error: axiosError.response?.data ? JSON.parse(JSON.stringify(axiosError.response)) : axiosError.message,
+      };
+    }
+  };
+
+  return { sendRequest };
+};

--- a/src/libs/axios/hooks/useGetService.ts
+++ b/src/libs/axios/hooks/useGetService.ts
@@ -1,0 +1,28 @@
+import { AxiosError } from "axios";
+
+import { useAxios } from "../context";
+
+export type UseGetServiceType = {
+  id: string | number;
+  url: string;
+};
+
+export const useGetService = <T>() => {
+  const axios = useAxios();
+
+  const sendRequest = async (props: UseGetServiceType): Promise<{ data?: T; error?: string }> => {
+    const { id, url } = props;
+    try {
+      const endpoint = `${url}/${id}`;
+      const response = await axios.get<T>(endpoint);
+      return { data: response.data };
+    } catch (err) {
+      const axiosError = err as AxiosError;
+      return {
+        error: axiosError.response?.data ? String(axiosError.response.data) : axiosError.message,
+      };
+    }
+  };
+
+  return { sendRequest };
+};

--- a/src/libs/axios/hooks/useUpdateService.ts
+++ b/src/libs/axios/hooks/useUpdateService.ts
@@ -1,0 +1,27 @@
+import { AxiosError } from "axios";
+
+import { useAxios } from "../context";
+
+export type UseUpdateServiceType<TPayload> = {
+  url: string;
+  payload: TPayload;
+};
+
+export const useUpdateService = <TResponse, TPayload>() => {
+  const axios = useAxios();
+
+  const sendRequest = async (props: UseUpdateServiceType<TPayload>): Promise<{ data?: TResponse; error?: string }> => {
+    const { url, payload } = props;
+    try {
+      const response = await axios.put<TResponse>(url, payload);
+      return { data: response.data };
+    } catch (err) {
+      const axiosError = err as AxiosError;
+      return {
+        error: axiosError.response?.data ? JSON.parse(JSON.stringify(axiosError.response)) : axiosError.message,
+      };
+    }
+  };
+
+  return { sendRequest };
+};

--- a/src/libs/axios/index.ts
+++ b/src/libs/axios/index.ts
@@ -1,2 +1,5 @@
 export * from "./axios";
 export * from "./types";
+export * from "./context";
+export * from "./service";
+export * from "./hooks";

--- a/src/libs/axios/service/context/AxiosServiceContext.tsx
+++ b/src/libs/axios/service/context/AxiosServiceContext.tsx
@@ -1,0 +1,35 @@
+import { createContext, ReactNode } from "react";
+
+import {
+  useCreateService,
+  useDeleteService,
+  useGetAllService,
+  useGetService,
+  useUpdateService,
+} from "@libs/axios/hooks";
+
+export type AxiosServiceContextType = {
+  getAllService: ReturnType<typeof useGetAllService>["sendRequest"];
+  getService: ReturnType<typeof useGetService>["sendRequest"];
+  createService: ReturnType<typeof useCreateService>["sendRequest"];
+  updateService: ReturnType<typeof useUpdateService>["sendRequest"];
+  deleteService: ReturnType<typeof useDeleteService>["sendRequest"];
+};
+
+export const AxiosServiceContext = createContext<AxiosServiceContextType | null>(null);
+
+export const AxiosServiceProvider = (props: { children: ReactNode }) => {
+  const { children } = props;
+
+  const { sendRequest: getAllService } = useGetAllService();
+  const { sendRequest: getService } = useGetService();
+  const { sendRequest: createService } = useCreateService();
+  const { sendRequest: updateService } = useUpdateService();
+  const { sendRequest: deleteService } = useDeleteService();
+
+  return (
+    <AxiosServiceContext.Provider value={{ getAllService, getService, createService, updateService, deleteService }}>
+      {children}
+    </AxiosServiceContext.Provider>
+  );
+};

--- a/src/libs/axios/service/context/index.ts
+++ b/src/libs/axios/service/context/index.ts
@@ -1,0 +1,3 @@
+export { AxiosServiceProvider } from "./AxiosServiceContext";
+export type { AxiosServiceContextType } from "./AxiosServiceContext";
+export { useAxiosService } from "./useAxiosService";

--- a/src/libs/axios/service/context/useAxiosService.ts
+++ b/src/libs/axios/service/context/useAxiosService.ts
@@ -1,0 +1,9 @@
+import { useContext } from "react";
+
+import { AxiosServiceContext } from "./AxiosServiceContext";
+
+export const useAxiosService = () => {
+  const context = useContext(AxiosServiceContext);
+  if (!context) throw new Error("useAxiosService must be used within AxiosServiceProvider");
+  return context;
+};

--- a/src/libs/axios/service/index.ts
+++ b/src/libs/axios/service/index.ts
@@ -1,0 +1,1 @@
+export * from "./context";


### PR DESCRIPTION
This PR contains the following changes:

- Service Provider for AxiosInstance
- Provider for using axios instance to make custom hooks

One thing I observed that, we don't need to create a custom provider for react query, keeping in mind we aim to use this in multiple services, the control, of managing the query should be given to the end user.